### PR TITLE
Remove lintr warnings

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,5 @@
 linters: with_defaults(object_name_linter(c("camelCase", "snake_case")))
-exclusions: list("data-raw/data.R")
+exclusions: list("data-raw/data.R",
+                 "data-raw/delivery.R",
+                 "data-raw/org.R",
+                 "data-raw/user.R")

--- a/.lintr
+++ b/.lintr
@@ -1,2 +1,2 @@
 linters: with_defaults(object_name_linter(c("camelCase", "snake_case")))
-exclusions: list("data-raw/*")
+exclusions: list("data-raw/data.R")

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -67,7 +67,7 @@ agg <- function(df, org, indicator) {
     idf <- compute_group(idf, indicator)
     idf$unit_level <- rep(unit_levels[i], dim(idf)[1])
     if (unit_levels[i] == "nasjonal") {
-      idf$OrgNr <- rep(0, dim(idf)[1])
+      idf$OrgNr <- rep(0, dim(idf)[1]) # nolint
       idf$unit_name <- rep("Nasjonal", dim(idf)[1])
     } else {
       idf <- idf %>%

--- a/R/ops.R
+++ b/R/ops.R
@@ -101,9 +101,9 @@ ORDER BY
   df <- pool::dbGetQuery(pool, query)
 
   # timestamp in db is UTC, convert back to "our" time zone
-  df$Dato <- format(df$Dato, format = conf$app_text$format$date,
+  df$Dato <- format(df$Dato, format = conf$app_text$format$date, # nolint
                     tz = Sys.getenv("TZ"))
-  df$Tid <- format(df$Tid, format = conf$app_text$format$time,
+  df$Tid <- format(df$Tid, format = conf$app_text$format$time, # nolint
                    tz = Sys.getenv("TZ"))
 
   df

--- a/tests/testthat/test-ops.R
+++ b/tests/testthat/test-ops.R
@@ -163,7 +163,7 @@ test_that("data from a registry can be fetched", {
 test_that("a new organization can be created", {
   check_db()
   df <- imongr::org[1, ]
-  df$OrgNrShus <- 10000000
+  df$OrgNrShus <- 10000000 # nolint
   expect_true(create_imongr_org(pool, df))
 })
 

--- a/tests/testthat/test-upload.R
+++ b/tests/testthat/test-upload.R
@@ -115,10 +115,10 @@ test_that("org id checks is workinig", {
   expect_equal(check_invalid_org(df[, !names(df) %in% "OrgNrShus"],
                                  conf, pool)$report, "Field missing")
   # set an org id that (assumably) does not exist
-  df$OrgNrShus <- 66
+  df$OrgNrShus <- 66 # nolint
   expect_true(check_invalid_org(df, conf, pool)$fail)
   expect_true(length(check_invalid_org(df, conf, pool)$report) > 0)
-  df$OrgNrShus <- 974795787
+  df$OrgNrShus <- 974795787 # nolint
 })
 
 test_that("indicator id check is working", {
@@ -127,9 +127,9 @@ test_that("indicator id check is working", {
   expect_equal(check_invalid_ind(df[, !names(df) %in% "KvalIndID"],
                                  conf, pool)$report, "Field missing")
   # set an indicator id that does not exist
-  df$KvalIndID <- "nothing"
+  df$KvalIndID <- "nothing" # nolint
   expect_true(length(check_invalid_ind(df, conf, pool)$report) > 0)
-  df$KvalIndID <- "norgast1"
+  df$KvalIndID <- "norgast1" # nolint
 })
 
 test_that("variable (numeric) type check is working", {
@@ -137,9 +137,9 @@ test_that("variable (numeric) type check is working", {
   expect_false(check_none_numeric_var(df, conf, pool)$fail)
   expect_equal(check_none_numeric_var(df[, !names(df) %in% "Variabel"],
                                      conf, pool)$report, "Field missing")
-  df$Variabel <- as.character(df$Variabel)
+  df$Variabel <- as.character(df$Variabel) # nolint
   expect_true(check_none_numeric_var(df, conf, pool)$fail)
-  df$Variabel <- as.numeric(df$Variabel)
+  df$Variabel <- as.numeric(df$Variabel) # nolint
 })
 
 test_that("duplicate delivery check is present (tested elsewhere)", {


### PR DESCRIPTION
Added nolint behind lines where PascalCase are used (variable names).

Should consider renaming OrgNr, KvalIndID etc.