### PR TITLE
Install binaries on github actions 

### DIFF
--- a/.github/workflows/R-CMD-check.yml
+++ b/.github/workflows/R-CMD-check.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE)
+          remotes::install_deps(dependencies = TRUE, type="binary")
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     pool,
     readr,
     rlang,
-    RMariaDB (!=1.2.2),
+    RMariaDB,
     rmarkdown,
     shiny (>= 1.5.0),
     shinyalert,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     pool,
     readr,
     rlang,
-    RMariaDB (==1.2.1),
+    RMariaDB (!=1.2.2),
     rmarkdown,
     shiny (>= 1.5.0),
     shinyalert,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     pool,
     readr,
     rlang,
-    RMariaDB,
+    RMariaDB (=1.2.1),
     rmarkdown,
     shiny (>= 1.5.0),
     shinyalert,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ Imports:
     pool,
     readr,
     rlang,
-    RMariaDB (=1.2.1),
+    RMariaDB (==1.2.1),
     rmarkdown,
     shiny (>= 1.5.0),
     shinyalert,


### PR DESCRIPTION
The source build of `RMariaDB` failed on Windows. Build dependencies with `type="binary"` to fix this. 

```r
remotes::install_deps(dependencies = TRUE, type="binary")
```
