### PR TITLE
Force dev service to use master version of mongr-dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
   dev:
     depends_on:
       - db
-    image: hnskde/mongr-dev
+    image: hnskde/mongr-dev:master
     restart: "no"
     volumes:
       - ~/.ssh:/home/rstudio/.ssh


### PR DESCRIPTION
Was probably using `latest`, which was outdated