### PR TITLE
Remove unnecessary enviroment statements in dev service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,18 +46,8 @@ services:
       - ~/.gitconfig:/home/rstudio/.gitconfig
     ports:
       - 8787:8787
-    dns:
-      - 8.8.8.8
     environment:
       PASSWORD: password
-      IMONGR_CONTEXT: DEV
-      IMONGR_DB_HOST: db
-      IMONGR_DB_HOST_VERIFY: db-verify
-      IMONGR_DB_HOST_QA: db-qa
-      IMONGR_DB_NAME: imongr
-      IMONGR_DB_USER: imongr
-      IMONGR_DB_PASS: imongr
-      IMONGR_ADMINER_URL: http://localhost:8888
 
   adminer:
     depends_on:


### PR DESCRIPTION
They are defined in mong/mongr-dev