### PR TITLE
Revert "Force dev service to use master version of mongr-dev (#232)"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   dev:
     depends_on:
       - db
-    image: hnskde/mongr-dev:master
+    image: hnskde/mongr-dev
     restart: "no"
     volumes:
       - ~/.ssh:/home/rstudio/.ssh


### PR DESCRIPTION
This reverts commit 90b2bd6284caff20fc0c70dbde99b32fdbd90d8e.

We have started with releases of mongr-dev and therefore latest tag will be the lastest release. It will also make it possible to install local versions of mongr-dev.