### PR TITLE
Allow 120 characters per line

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,5 @@
-linters: with_defaults(object_name_linter(c("camelCase", "snake_case")),
-                       cyclocomp_linter(complexity_limit = 25))
+linters: linters_with_defaults(object_name_linter(c("camelCase", "snake_case")),
+                       cyclocomp_linter(complexity_limit = 25),
+                       line_length_linter(length = 120L))
 exclusions: list("data-raw/delivery.R", "data-raw/data.R", "data-raw/org.R", "data-raw/user.R")
 


### PR DESCRIPTION
+ Use linters_with_defaults instead of with_defaults (deprecated)