### PR TITLE
Remove choose encoding option

### DIFF
--- a/R/mod_upload.R
+++ b/R/mod_upload.R
@@ -30,12 +30,6 @@ upload_ui <- function(id) {
                             choices = c(Punktum = ".",
                                         Komma = ","),
                             selected = ","),
-        shiny::radioButtons(ns("enc"), "Tegnsetting",
-                            choices = c("LATIN1",
-                                        "UTF-8",
-                                        "Annet"),
-                            selected = "UTF-8"),
-        shiny::uiOutput(outputId = ns("other_encoding")),
         shiny::numericInput(ns("sample_size"),
                             "Antall rader vist:",
                             20,
@@ -125,20 +119,11 @@ upload_server <- function(id, pool_verify) {
 
 
     ## reactives
-    encoding <- shiny::reactive({
-      if (input$enc == "Annet") {
-        input$other_encoding
-      } else {
-        input$enc
-      }
-    })
-
     df <- shiny::reactive({
       if (is.null(input$upload_file)) {
         data.frame()
       } else {
-        csv_to_df(input$upload_file$datapath, input$sep, input$dec_sep,
-                  encoding())
+        csv_to_df(input$upload_file$datapath, input$sep, input$dec_sep)
       }
     })
 
@@ -165,15 +150,6 @@ upload_server <- function(id, pool_verify) {
                                   "text/comma-separated-values,text/plain",
                                   ".csv")
       )
-    })
-
-    output$other_encoding <- shiny::renderUI({
-      if (input$enc == "Annet") {
-        shiny::selectInput(inputId = ns("other_encoding"),
-                           label = "Spesifiser:",
-                           choices = iconvlist(),
-                           selected = "MS-ANSI")
-      }
     })
 
     output$submit <- shiny::renderUI({

--- a/tests/testthat/test-mod.R
+++ b/tests/testthat/test-mod.R
@@ -325,20 +325,13 @@ test_that("upload module has output...", {
         registry = 10,
         sep = ";",
         dec_sep = ",",
-        enc = "UTF-8",
-        other_encoding = "MS-ANSI",
         sample_size = 20,
         sample_type = TRUE,
         latest_update = "2022-12-24",
         latest_affirm = "2022-01-01"
       )
-      expect_equal(encoding(), "UTF-8")
       expect_equal_to_reference(ind(), "data/norgast_ind.rds")
       expect_equal(df(), data.frame())
-      session$setInputs(
-        enc = "Annet",
-      )
-      expect_equal(encoding(), "MS-ANSI")
     }
   )
 })


### PR DESCRIPTION
The data will only contain numbers, ind_id and context. Thus, no non-ascii characters.