### PR TITLE
Mulighet til å velge gult målnivå hvis grønn er NULL

### DIFF
--- a/R/mod_indicator.R
+++ b/R/mod_indicator.R
@@ -237,7 +237,7 @@ indicator_server <- function(id, pool) {
     })
 
     output$set_level_yellow <- shiny::renderUI({
-      shiny::req(input$indicator, rv$ind_data$level_yellow)
+      shiny::req(input$indicator)
       shiny::tags$div(
         title = "Grenseverdi for middels m\u00e5loppn\u00e5else",
         shiny::numericInput(


### PR DESCRIPTION
`set_level_yellow` ble ikke vist hvis `level_yellow` var `NULL` i databasen. Dette ga en del kluss siden `level_yellow` fra tidligere indikator ble bruk i app for å bestemme om grønt nivå var riktig satt (`level_consistent`).

Closes #271