### PR TITLE
Fjern anførselstegn i csv-filer som lastes ned

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     shinyjs,
     tibble,
     yaml
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Suggests: 
     testthat (>= 2.1.0),
     covr,

--- a/R/mod_download.R
+++ b/R/mod_download.R
@@ -108,8 +108,8 @@ download_server <- function(id, pool, pool_verify) {
       },
       content = function(file) {
         switch(input$file_format,
-               `csv` = readr::write_excel_csv(db_table(), file),
-               `csv (nordisk)` = readr::write_excel_csv2(db_table(), file),
+               `csv` = readr::write_csv(db_table(), file),
+               `csv (nordisk)` = readr::write_csv2(db_table(), file),
                `rds` = readr::write_rds(db_table(), file)
         )
       }


### PR DESCRIPTION
Fikser #281. Nedlastede filer i csv-format har ikke lenger " " rundt strenger. 