### PR TITLE
update_aggdata_delivery kun på aktuelle register

### DIFF
--- a/R/db_get.R
+++ b/R/db_get.R
@@ -484,7 +484,7 @@ WHERE
 
 #' @rdname db_get
 #' @export
-get_aggdata_delivery <- function(pool) {
+get_aggdata_delivery <- function(pool, ind_id) {
   # get current delivery ids in data
   query <- paste0("
 SELECT
@@ -493,6 +493,7 @@ SELECT
   MAX(delivery_id) as id
 FROM
   data
+WHERE ind_id IN ('", paste(ind_id, collapse = "', '"), "')
 GROUP BY
   ind_id,
   context;")

--- a/R/db_get.R
+++ b/R/db_get.R
@@ -484,7 +484,7 @@ WHERE
 
 #' @rdname db_get
 #' @export
-get_aggdata_delivery <- function(pool, ind_id) {
+get_aggdata_delivery <- function(pool, indicator) {
   # get current delivery ids in data
   query <- paste0("
 SELECT
@@ -493,7 +493,7 @@ SELECT
   MAX(delivery_id) as id
 FROM
   data
-WHERE ind_id IN ('", paste(ind_id, collapse = "', '"), "')
+WHERE ind_id IN ('", paste(indicator, collapse = "', '"), "')
 GROUP BY
   ind_id,
   context;")

--- a/R/ops.R
+++ b/R/ops.R
@@ -3,6 +3,7 @@
 #' @param pool Database connection pool object
 #' @param df Data frame of relevant data
 #' @param ind Data frame of relevant indicator data
+#' @param ind_id List of indicators id
 #' @param registry Integer registry id
 #' @param update Character string of format YYYY-MM-DD providing date until data
 #'   are regarded as updated. Default value is NA.

--- a/R/ops.R
+++ b/R/ops.R
@@ -3,7 +3,7 @@
 #' @param pool Database connection pool object
 #' @param df Data frame of relevant data
 #' @param ind Data frame of relevant indicator data
-#' @param ind_id List of indicators id
+#' @param indicator Character vector of indicator ids
 #' @param registry Integer registry id
 #' @param update Character string of format YYYY-MM-DD providing date until data
 #'   are regarded as updated. Default value is NA.
@@ -241,8 +241,8 @@ insert_agg_data <- function(pool, df) {
 
 #' @rdname ops
 #' @export
-update_aggdata_delivery <- function(pool, ind_id) {
-  delivery <- get_aggdata_delivery(pool, ind_id)
+update_aggdata_delivery <- function(pool, indicator) {
+  delivery <- get_aggdata_delivery(pool, indicator)
 
   pool::dbWriteTable(pool,
     name = "temp_agg_data", value = delivery,

--- a/R/ops.R
+++ b/R/ops.R
@@ -232,8 +232,10 @@ insert_agg_data <- function(pool, df) {
     insert_table(pool, "agg_data", dat)
   }
   message("\nUpdating delivery timings")
-  ind_id <- unique(df$ind_id)
-  update_aggdata_delivery(pool, ind_id)
+  # Get all indicator ids from delivered registries,
+  # since all dates are removed from agg_data in the loop above.
+  all_ind_id <- dplyr::filter(ind_reg, .data$registry_id %in% reg)$id
+  update_aggdata_delivery(pool, all_ind_id)
   message("Done!")
 }
 

--- a/R/ops.R
+++ b/R/ops.R
@@ -231,14 +231,15 @@ insert_agg_data <- function(pool, df) {
     insert_table(pool, "agg_data", dat)
   }
   message("\nUpdating delivery timings")
-  update_aggdata_delivery(pool)
+  ind_id <- unique(df$ind_id)
+  update_aggdata_delivery(pool, ind_id)
   message("Done!")
 }
 
 #' @rdname ops
 #' @export
-update_aggdata_delivery <- function(pool) {
-  delivery <- get_aggdata_delivery(pool)
+update_aggdata_delivery <- function(pool, ind_id) {
+  delivery <- get_aggdata_delivery(pool, ind_id)
 
   pool::dbWriteTable(pool,
     name = "temp_agg_data", value = delivery,

--- a/man/db_get.Rd
+++ b/man/db_get.Rd
@@ -70,7 +70,7 @@ get_registry_user(pool, registry)
 
 get_user_registry(pool, user)
 
-get_aggdata_delivery(pool, ind_id)
+get_aggdata_delivery(pool, indicator)
 
 get_aggdata(pool, registry)
 }

--- a/man/db_get.Rd
+++ b/man/db_get.Rd
@@ -70,7 +70,7 @@ get_registry_user(pool, registry)
 
 get_user_registry(pool, user)
 
-get_aggdata_delivery(pool)
+get_aggdata_delivery(pool, ind_id)
 
 get_aggdata(pool, registry)
 }

--- a/man/ops.Rd
+++ b/man/ops.Rd
@@ -35,7 +35,7 @@ insert_data_prod(
 
 insert_agg_data(pool, df)
 
-update_aggdata_delivery(pool, ind_id)
+update_aggdata_delivery(pool, indicator)
 
 agg_all_data(pool)
 
@@ -66,7 +66,7 @@ are regarded as final. Default value is NA.}
 accepted when data are published. Default value is NA that will normally
 apply for all uploads prior to publishing.}
 
-\item{ind_id}{List of indicators id}
+\item{indicator}{Character vector of indicator ids}
 
 \item{ind}{Data frame of relevant indicator data}
 

--- a/man/ops.Rd
+++ b/man/ops.Rd
@@ -35,7 +35,7 @@ insert_data_prod(
 
 insert_agg_data(pool, df)
 
-update_aggdata_delivery(pool)
+update_aggdata_delivery(pool, ind_id)
 
 agg_all_data(pool)
 

--- a/man/ops.Rd
+++ b/man/ops.Rd
@@ -66,6 +66,8 @@ are regarded as final. Default value is NA.}
 accepted when data are published. Default value is NA that will normally
 apply for all uploads prior to publishing.}
 
+\item{ind_id}{List of indicators id}
+
 \item{ind}{Data frame of relevant indicator data}
 
 \item{registry}{Integer registry id}

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -291,7 +291,9 @@ test_that("users registries can be updated", {
 
 test_that("aggdata delivery timings can be provided", {
   check_db()
-  aggdata_delivery <- get_aggdata_delivery(pool, c("dummy_ind_id"))
+  aggdata_delivery <- get_aggdata_delivery(pool, c("norgast_andel_avdoede_bykspytt_tolv",
+                                                   "norgast_saarruptur"))
+  expect_equal((length(aggdata_delivery$id)), 243)
   expect_equal(class(aggdata_delivery), "data.frame")
   expect_true(class(aggdata_delivery$id) %in% c("integer"))
   expect_true(

--- a/tests/testthat/test-db.R
+++ b/tests/testthat/test-db.R
@@ -291,7 +291,7 @@ test_that("users registries can be updated", {
 
 test_that("aggdata delivery timings can be provided", {
   check_db()
-  aggdata_delivery <- get_aggdata_delivery(pool)
+  aggdata_delivery <- get_aggdata_delivery(pool, c("dummy_ind_id"))
   expect_equal(class(aggdata_delivery), "data.frame")
   expect_true(class(aggdata_delivery$id) %in% c("integer"))
   expect_true(

--- a/tests/testthat/test-ops.R
+++ b/tests/testthat/test-ops.R
@@ -157,7 +157,7 @@ test_that("agg data can be cleaned", {
 
 test_that("agg_data delivery timings can be updated without errors", {
   check_db()
-  expect_invisible(update_aggdata_delivery(pool))
+  expect_invisible(update_aggdata_delivery(pool, c("dummy")))
 })
 
 test_that("a new user can be created", {

--- a/tests/testthat/test-ops.R
+++ b/tests/testthat/test-ops.R
@@ -157,7 +157,7 @@ test_that("agg data can be cleaned", {
 
 test_that("agg_data delivery timings can be updated without errors", {
   check_db()
-  expect_invisible(update_aggdata_delivery(pool, c("dummy")))
+  expect_invisible(update_aggdata_delivery(pool, c("norgast_saarruptur")))
 })
 
 test_that("a new user can be created", {


### PR DESCRIPTION
Gikk tidligere gjennom alle indikatorene og dataene i hele databasen. Dette tok veldig lang tid.

Closes #216