### PR TITLE
Fjernet dplyr-advarsel

### DIFF
--- a/R/ops.R
+++ b/R/ops.R
@@ -189,7 +189,7 @@ insert_agg_data <- function(pool, df) {
   ## the aggregate
   orgnr_name_map <- get_all_orgnr(pool, include_short_name = TRUE) %>%
     dplyr::select("orgnr", "short_name") %>%
-    dplyr::rename(unit_name = .data$short_name)
+    dplyr::rename(unit_name = "short_name")
 
 
   # make sure we have unit_levels


### PR DESCRIPTION
```
Warning (test-db.R:128:3): agg_data can be populated from existing (test) data
Use of .data in tidyselect expressions was deprecated in tidyselect 1.2.0.
ℹ Please use `"short_name"` instead of `.data$short_name`
Backtrace:
     ▆
  1. ├─testthat::expect_message(insert_agg_data(pool, data_sample)) at test-db.R:128:2
  2. │ └─testthat:::quasi_capture(enquo(object), label, capture_messages)
  3. │   ├─testthat (local) .capture(...)
  4. │   │ └─base::withCallingHandlers(...)
  5. │   └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
  6. ├─imongr::insert_agg_data(pool, data_sample)
  7. │ └─... %>% dplyr::rename(unit_name = .data$short_name) at imongr/R/ops.R:190:2
  8. ├─dplyr::rename(., unit_name = .data$short_name)
  9. └─dplyr:::rename.data.frame(., unit_name = .data$short_name)
 10.   └─tidyselect::eval_rename(expr(c(...)), .data)
 11.     └─tidyselect:::rename_impl(...)
 12.       └─tidyselect:::eval_select_impl(...)
 13.         ├─tidyselect:::with_subscript_errors(...)
 14.         │ └─rlang::try_fetch(...)
 15.         │   └─base::withCallingHandlers(...)
 16.         └─tidyselect:::vars_select_eval(...)
 17.           └─tidyselect:::walk_data_tree(expr, data_mask, context_mask)
 18.             └─tidyselect:::eval_c(expr, data_mask, context_mask)
 19.               └─tidyselect:::reduce_sels(node, data_mask, context_mask, init = init)
 20.                 └─tidyselect:::walk_data_tree(new, data_mask, context_mask)
 21.                   └─tidyselect:::expr_kind(expr, context_mask, error_call)
 22.                     └─tidyselect:::call_kind(expr, context_mask, error_call)
 ```