### PR TITLE
Install older version of bslib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ WORKDIR /app/R
 COPY *.tar.gz .
 
 ## install package, clean up and make sure sufficient latex tools exists in base image
-RUN R CMD INSTALL --clean ./*.tar.gz \
+RUN R -e "install.packages('remotes')" \
+    # imongr did not work with bslib v6 when setting bootstrap version to 4
+    # See issue https://github.com/mong/imongr/issues/380
+    && R -e "remotes::install_github('rstudio/bslib@v0.5.1')" \
+    && R CMD INSTALL --clean ./*.tar.gz \
     && rm ./*.tar.gz \
     && R -e "rmarkdown::render(input = system.file('terms.Rmd', package = 'imongr'), output_format = 'pdf_document')"
 


### PR DESCRIPTION
imongr did not work with bslib v6 when setting bootstrap version to 4. See issue #380

Will probably be a problem when imongr-base-r are updated