### PR TITLE
Prep. for alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,13 @@ WORKDIR /app/R
 COPY *.tar.gz .
 
 ## install package, clean up and make sure sufficient latex tools exists in base image
-RUN R -e "install.packages('remotes')" \
+RUN R -e "install.packages('remotes', repos='https://cloud.r-project.org/')" \
     # imongr did not work with bslib v6 when setting bootstrap version to 4
     # See issue https://github.com/mong/imongr/issues/380
     && R -e "remotes::install_github('rstudio/bslib@v0.5.1')" \
     && R CMD INSTALL --clean ./*.tar.gz \
     && rm ./*.tar.gz \
-    && R -e "rmarkdown::render(input = system.file('terms.Rmd', package = 'imongr'), output_format = 'pdf_document')"
+    && R -e "rmarkdown::render(input = system.file('terms.Rmd', package = 'imongr'), output_format = 'html_fragment')"
 
 EXPOSE 3838
 

--- a/R/mod_publish.R
+++ b/R/mod_publish.R
@@ -91,13 +91,12 @@ publish_server <- function(id, tab_tracker, registry_tracker, pool, pool_verify)
     # Download terms handler
     output$downloadTerms <- shiny::downloadHandler(
       filename = basename(
-        tempfile(pattern = "VilkaarPubliseringSKDE", fileext = ".pdf")
+        tempfile(pattern = "VilkaarPubliseringSKDE", fileext = ".html")
       ),
       content = function(file) {
         fn <- rmarkdown::render(
           input = system.file("terms.Rmd", package = "imongr"),
-          output_format = "pdf_document",
-          params = list(output = "pdf")
+          output_format = "html_document"
         )
         file.rename(fn, file)
       }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.6'
 
 x-db: &db
-  image: mariadb
+  image: mariadb:10
   restart: "no"
   environment:
     MYSQL_ROOT_PASSWORD: root

--- a/inst/terms.Rmd
+++ b/inst/terms.Rmd
@@ -15,15 +15,6 @@ fontsize: 10pt
 links-as-notes: true
 ---
 
-```{r printlayout, results = "asis", echo = FALSE, eval = (params$output == "pdf")}
-cat(
-  paste(
-    "\n\n\\hyphenation{kvalitets-registre opplys-ninger identi-fiserbar",
-    "hend-elser hand-linger}\n\n"
-  )
-)
-```
-
 ## 1. Formål
 Formålet med dette dokumentet er å regulere vilkår for å publisere anonyme opplysninger fra nasjonale medisinske kvalitetsregistre på Senter for klinisk dokumentasjon og evaluering (SKDE) sine nettsider.
 


### PR DESCRIPTION
Dropper pdf av terms. Kjører på MariaDB 10 i stedet for 11. Fjernet innhold i rmd-fil som ga feilmelding om Cairo