### PR TITLE
Dropp bruk av bslib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,7 @@ WORKDIR /app/R
 COPY *.tar.gz .
 
 ## install package, clean up and make sure sufficient latex tools exists in base image
-RUN R -e "install.packages('remotes', repos='https://cloud.r-project.org/')" \
-    # imongr did not work with bslib v6 when setting bootstrap version to 4
-    # See issue https://github.com/mong/imongr/issues/380
-    && R -e "remotes::install_github('rstudio/bslib@v0.5.1')" \
-    && R CMD INSTALL --clean ./*.tar.gz \
+RUN R CMD INSTALL --clean ./*.tar.gz \
     && rm ./*.tar.gz \
     && R -e "rmarkdown::render(input = system.file('terms.Rmd', package = 'imongr'), output_format = 'html_fragment')"
 

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -19,24 +19,6 @@ app_ui <- function() {
       )
     ),
     shiny::navbarPage(
-      theme = bslib::bs_theme(
-        version = 4,
-        bg = "#FFFFFF",
-        fg = "#1E1E1E",
-        primary = "#007bff",
-        secondary = "#D5D3D3",
-        base_font = bslib::font_collection(
-          "Arial", "Helvetica",
-          "sans-serif"
-        ),
-        heading_font = bslib::font_collection(
-          "Arial",
-          "Helvetica", "sans-serif"
-        ),
-        font_scale = 0.95,
-        spacer = "0.5rem",
-        `enable-shadows` = TRUE
-      ),
       title = shiny::div(app_title),
       windowTitle = app_title,
       id = "tabs",

--- a/R/misc.R
+++ b/R/misc.R
@@ -58,17 +58,19 @@ md5_checksum <- function(df, ind = "") {
 user_widget <- function() {
   conf <- get_config()
 
-  bslib::nav_menu(
+  shiny::navbarMenu(
     get_user_name(),
     align = "right",
-    bslib::nav_item(
+    shiny::tabPanel(
       shiny::tags$a(
         shiny::icon("info-circle"),
         id = "app_info",
         href = "#",
         class = "action-button",
         "Informasjon",
-      ),
+      )
+    ),
+    shiny::tabPanel(
       shiny::tags$a(
         shiny::icon("sign-out-alt"),
         conf$profile$logout$text,


### PR DESCRIPTION
**OBS! Går da fra bootstrap 4 til 3**

`bslib` brukes nå kun til høyrejustering av bruker-nedtrekkmeny.

Gammel design:

![image](https://github.com/mong/imongr/assets/136346/05cf6a31-989e-4a48-b91a-ecfbad8f1222)


Ny design:

![image](https://github.com/mong/imongr/assets/136346/0fac7070-0376-4ba2-8316-72d7b92b4c18)

Ved å ikke bruke masse `bslib`-styling faller vi tilbake på `shiny` sin default bootstrap-versjon. Usikker på om det er noe vi ønsker? 

~~Closes #380~~ Siden vi havner på en gammel versjon av bootstrap kan vi ikke lukke denne...