### PR TITLE
Angi versjon av docker image i docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
   dev:
     depends_on:
       - db
-    image: hnskde/mongr-dev-rstudio:latest
+    image: hnskde/mongr-dev-rstudio:2.1.1
     restart: "no"
     volumes:
       - ~/.ssh:/home/rstudio/.ssh
@@ -59,7 +59,7 @@ services:
   code-server:
     depends_on:
       - db
-    image: hnskde/mongr-dev-code-server:latest
+    image: hnskde/mongr-dev-code-server:2.1.1
     restart: "no"
     volumes:
       - ~/.ssh:/home/coder/.ssh
@@ -73,7 +73,7 @@ services:
       IMONGR_CONTEXT: DEV
 
   app:
-    image: hnskde/imongr:latest
+    image: hnskde/imongr:2.1.0
     ports:
       - 3838:3838
     environment:


### PR DESCRIPTION
Nye versjoner av utviklingsmiljø etc. ble ikke hentet ned automatisk, så man kunne ende opp med å kjøre eldre versjoner