### PR TITLE
Fiks tegnforklaring i graf

### DIFF
--- a/R/mod_review.R
+++ b/R/mod_review.R
@@ -516,29 +516,32 @@ review_server <- function(id, registry_tracker, pool) {
         colour_map <- c("#648FFF", "#DC267F", "#FE6100", "#AAAAAA")
         names(colour_map) <- c("A", "B", "C", NA)
 
+        base_plot <- ggplot2::ggplot(data = plot_data, ggplot2::aes(x = year)) + # nolint: object_usage_linter.
+          ggplot2::scale_x_continuous("År", 2013:get_last_year(), limits = c(2013, get_last_year())) +
+          ggplot2::scale_colour_manual(values = colour_map, limits = c("A", "B", "C", NA)) +
+          ggplot2::theme_classic() +
+          ggplot2::theme(text = ggplot2::element_text(size = 14)) +
+          ggplot2::guides(colour = ggplot2::guide_legend(title = "Niv\u00e5"))
+
         if (!input$show_dg_plot) {
-          ggplot2::ggplot(data = plot_data, ggplot2::aes(x = year, y = stage)) + # nolint: object_usage_linter.
-            ggplot2::geom_line() +
-            ggplot2::geom_point(ggplot2::aes(colour = factor(level)), size = 3) + # nolint: object_usage_linter.
-            ggplot2::scale_x_continuous("År", 2013:get_last_year(), limits = c(2013, get_last_year())) +
-            ggplot2::scale_y_continuous("Stadium", 1:4, limits = c(1, 4)) +
-            ggplot2::scale_colour_manual(values = colour_map, limits = c("A", "B", "C", NA)) +
-            ggplot2::theme_classic() +
-            ggplot2::theme(text = ggplot2::element_text(size = 14)) +
-            ggplot2::guides(colour = ggplot2::guide_legend(title = "Niv\u00e5"))
+          output_plot <- base_plot +
+            ggplot2::geom_line(ggplot2::aes(y = stage)) + # nolint: object_usage_linter.
+            ggplot2::geom_point(ggplot2::aes(y = stage, colour = factor(level)), # nolint: object_usage_linter.
+                                size = 3,
+                                show.legend = c(colour = TRUE)) + # nolint: object_usage_linter.
+            ggplot2::scale_y_continuous("Stadium", 1:4, limits = c(1, 4))
         } else {
-          ggplot2::ggplot(data = plot_data, ggplot2::aes(x = year, y = reported_dg)) + # nolint: object_usage_linter.
-            ggplot2::geom_line() +
-            ggplot2::geom_point(ggplot2::aes(colour = factor(level)), size = 3) + # nolint: object_usage_linter.
-            ggplot2::scale_x_continuous("År", 2013:get_last_year(), limits = c(2013, get_last_year())) +
-            ggplot2::scale_y_continuous("Oppgitt dekningsgrad", limits = c(0, 100)) +
-            ggplot2::scale_colour_manual(values = colour_map, limits = c("A", "B", "C", NA)) +
-            ggplot2::theme_classic() +
-            ggplot2::theme(text = ggplot2::element_text(size = 14)) +
-            ggplot2::guides(colour = ggplot2::guide_legend(title = "Niv\u00e5"))
+          output_plot <- base_plot +
+            ggplot2::geom_line(ggplot2::aes(y = reported_dg)) + # nolint: object_usage_linter.
+            ggplot2::geom_point(ggplot2::aes(y = reported_dg, colour = factor(level)), # nolint: object_usage_linter.
+                                size = 3) + # nolint: object_usage_linter.
+            ggplot2::scale_y_continuous("Oppgitt dekningsgrad", limits = c(0, 100))
         }
+
+        return(output_plot)
       })
     })
+
 
     return(rv_return)
   })

--- a/R/mod_review.R
+++ b/R/mod_review.R
@@ -528,13 +528,14 @@ review_server <- function(id, registry_tracker, pool) {
             ggplot2::geom_line(ggplot2::aes(y = stage)) + # nolint: object_usage_linter.
             ggplot2::geom_point(ggplot2::aes(y = stage, colour = factor(level)), # nolint: object_usage_linter.
                                 size = 3,
-                                show.legend = c(colour = TRUE)) + # nolint: object_usage_linter.
+                                show.legend = c(colour = TRUE)) +
             ggplot2::scale_y_continuous("Stadium", 1:4, limits = c(1, 4))
         } else {
           output_plot <- base_plot +
             ggplot2::geom_line(ggplot2::aes(y = reported_dg)) + # nolint: object_usage_linter.
             ggplot2::geom_point(ggplot2::aes(y = reported_dg, colour = factor(level)), # nolint: object_usage_linter.
-                                size = 3) + # nolint: object_usage_linter.
+                                size = 3,
+                                show.legend = c(colour = TRUE)) +
             ggplot2::scale_y_continuous("Oppgitt dekningsgrad", limits = c(0, 100))
         }
 


### PR DESCRIPTION
[Endringer i ggplot versjon 3.5.0](https://ggplot2.tidyverse.org/news/index.html) gjør at symboler i tegnforklaringen ikke vises hvis det ikke finnes data: 

> By default, [guide_legend()](https://ggplot2.tidyverse.org/reference/guide_legend.html) now only draws a key glyph for a layer when the value is in the layer’s data. To revert to the old behaviour, you can still set show.legend = c({aesthetic} = TRUE)