### PR TITLE
Fjernet type dg_beregnet_andel

### DIFF
--- a/R/db_get.R
+++ b/R/db_get.R
@@ -414,11 +414,7 @@ get_dg_indicators <- function(pool, registry) {
     ind
   WHERE
     registry_id = ", registry, "
-  AND (
-    type = 'dg_andel'
-  OR
-    type = 'dg_beregnet_andel'
-    )
+  AND type = 'dg_andel'
   "
   )
 

--- a/inst/imongr.yml
+++ b/inst/imongr.yml
@@ -439,7 +439,6 @@ indicator:
   - gjennomsnitt
   - median
   - dg_andel
-  - dg_beregnet_andel
   formats: 
   - '%'
   - f


### PR DESCRIPTION
Ingen indikatorer som lenger har denne typen, og vi vil heller ikke ha den