### PR TITLE
Fjernet advarsel om 'legacy key/value format' i docker-fil

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM hnskde/imongr-base-r:4.1.0
 
-LABEL maintainer "Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
+LABEL maintainer="Arnfinn Hykkerud Steindal <arnfinn.hykkerud.steindal@helse-nord.no>"
 LABEL no.mongr.cd.enable="true"
 
 WORKDIR /app/R


### PR DESCRIPTION
Dukket opp i alle pull requests