### PR TITLE
Navn på valg av format i indikatorfane

### DIFF
--- a/R/mod_indicator.R
+++ b/R/mod_indicator.R
@@ -417,7 +417,9 @@ indicator_server <- function(id, registry_tracker, pool, pool_verify) {
         ),
         shiny::selectInput(
           ns("format"), "Indikatorformat:",
-          choices = conf$indicator$formats, selected = rv$sformat$format
+          choices = setNames(
+            as.list(conf$indicator$formats), conf$indicator$format_labels
+          ), selected = rv$sformat$format
         )
       )
     })

--- a/R/mod_indicator.R
+++ b/R/mod_indicator.R
@@ -413,7 +413,7 @@ indicator_server <- function(id, registry_tracker, pool, pool_verify) {
       shiny::req(input$indicator)
       shiny::tags$div(
         title = paste(
-          "Angir om indikatoren er oppgitt i prosent (%) eller siffer (f)"
+          "Angir om indikatoren er oppgitt i prosent eller desimaltall"
         ),
         shiny::selectInput(
           ns("format"), "Indikatorformat:",

--- a/inst/imongr.yml
+++ b/inst/imongr.yml
@@ -448,6 +448,9 @@ indicator:
   formats: 
   - '%'
   - f
+  format_labels:
+  - prosent
+  - desimaltall
   level_inconsistent_message: >
       <i style='color:red;'>
       Verdier for måloppnåelse er ikke konsistente!


### PR DESCRIPTION
Nedtrekksmenyen til indikatorformat viser nå "prosent" og "desimaltall" istedenfor "%" og "f": 

![image](https://github.com/user-attachments/assets/1b32b812-e1e1-49b4-bab1-1f9a50db4cef)
