### PR TITLE
API i docker-compose-fila

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,3 +87,16 @@ services:
     ports:
       - 8888:8080
 
+  api:
+    depends_on:
+      - db
+    image: hnskde/mong-api:latest
+    restart: "no"
+    environment:
+      DB_HOST: db
+      DB_NAME: imongr
+      DB_PWD: imongr
+      DB_USR: imongr
+      ORIGIN: blablabla
+    ports:
+      - 8000:80

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
   api:
     depends_on:
       - db
-    image: hnskde/mong-api:latest
+    image: hnskde/mong-api:develop
     restart: "no"
     environment:
       DB_HOST: db


### PR DESCRIPTION
Gjør det mulig å kjøre opp api-docker-image lokalt, som bruker db-instansen for å hente data.