### PR TITLE
Fikset bug i brukerliste og fagområdeliste

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -19,14 +19,14 @@ app_server <- function(input, output, session) {
   pool_verify <- make_pool(context = "verify")
   rv <- shiny::reactiveValues(
     context = "verify",
-    medfield_data = get_table(pool, "medfield"),
+    medfield_data = get_table(pool_verify, "medfield"),
     medfield_summary = medfield_summary_text_ui(
-      pool, conf,
-      get_table(pool, "medfield")
+      pool_verify, conf,
+      get_table(pool_verify, "medfield")
     ),
-    user_data = get_users(pool),
+    user_data = get_users(pool_verify),
     user_summary =
-      reguser_summary_text_ui(pool, conf, get_users(pool)),
+      reguser_summary_text_ui(pool_verify, conf, get_users(pool_verify)),
     publish_reg = character(),
     download_reg = character(),
     indicator_data = data.frame(),


### PR DESCRIPTION
Imongr starter opp admin-fanen med verify som kontekst, men henter data fra prod. Listene over fagområder og brukere viser derfor prod-data frem til at man endrer kontekst eller trykker på knappen for å oppdatere. 