### PR TITLE
Fiks lintr-jobb

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,4 @@
 linters: linters_with_defaults(object_name_linter(c("camelCase", "snake_case")),
-                       line_length_linter(length = 120L),
-                       cyclocomp_linter(complexity_limit = 20L))
+                       line_length_linter(length = 120L))
 exclusions: list("data-raw/delivery.R", "data-raw/data.R", "data-raw/org.R", "data-raw/user.R")
 

--- a/.lintr
+++ b/.lintr
@@ -1,4 +1,6 @@
 linters: linters_with_defaults(object_name_linter(c("camelCase", "snake_case")),
-                       line_length_linter(length = 120L))
+                       line_length_linter(length = 120L),
+                       return_linter = NULL
+                       )
 exclusions: list("data-raw/delivery.R", "data-raw/data.R", "data-raw/org.R", "data-raw/user.R")
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -177,7 +177,7 @@ reference:
 
   - title: internal
     contents:
+    - checks
     - check_no_dg
-    - levels_consistent_check
     - oversize_check
 


### PR DESCRIPTION
cyclo-greiene kjøres ikke lenger som default, og ville trengt en pakke for å kjøre