### PR TITLE
Fikset bug i projektfanen

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -166,7 +166,6 @@ update_check <- function(input, conf, ns, rv, level_consistent) {
 update_project_val_check <- function(input, conf, ns, rv, years_consistent) {
   missing_values <- any(c(
     is.null(input$start_year),
-    is.null(input$end_year),
     is.na(input$start_year),
     nrow(rv$project_data) == 0
   ))

--- a/R/mod_project.R
+++ b/R/mod_project.R
@@ -56,10 +56,10 @@ project_server <- function(id, registry_tracker, pool, pool_verify) {
     rv_return <- shiny::reactiveValues()
     rv <- shiny::reactiveValues()
 
-    project_data <- shiny::reactive({
+    project_data <- function() {
       get_registry_projects(pool_verify, input$project_registry, input$project_indicator) |>
         dplyr::filter(.data$id == input$project)
-    })
+    }
 
     hospital_unit_names <- get_hospitals(pool_verify)$short_name
 


### PR DESCRIPTION
Hvis man oppdaterer årstall og deretter oppdaterer tekst vil knappen for å oppdatere verdier vises. Dette skjer fordi prosjektverdiene er en reaktiv variabel som ikke trigges av at man oppdaterer verdier. 

I tillegg skal ikke `end_year` regnes som en manglende verdi. Den vil uansett være `NA` og ikke `NULL`. 