### PR TITLE
Fullt indikatornavn i faner for kvalitetsforbedring og utvalgte indikatorer

### DIFF
--- a/R/db_get.R
+++ b/R/db_get.R
@@ -433,7 +433,7 @@ FROM
 get_registry_indicators <- function(pool, registry) {
   query <- paste0("
 SELECT
-  id
+  id, title
 FROM
   ind
 WHERE

--- a/R/mod_project.R
+++ b/R/mod_project.R
@@ -137,7 +137,7 @@ project_server <- function(id, registry_tracker, pool, pool_verify) {
       shiny::req(input$project_registry)
       shiny::selectInput(
         ns("project_indicator"), "Velg indikator:",
-        choices = get_registry_indicators(pool_verify, input$project_registry)$id,
+        choices = rv$registry_indicators
       )
     })
 
@@ -225,6 +225,10 @@ project_server <- function(id, registry_tracker, pool, pool_verify) {
     # When you select a registry
     shiny::observeEvent(input$project_registry, {
       rv_return$registry_id <- input$indicator_registry
+      registry_indicators <- get_registry_indicators(pool_verify, input$project_registry)
+
+      rv$registry_indicators <- as.list(registry_indicators$id)
+      names(rv$registry_indicators) <- registry_indicators$title
     })
 
     # When you select a project

--- a/R/mod_selected_indicators.R
+++ b/R/mod_selected_indicators.R
@@ -61,6 +61,10 @@ selected_indicators_server <- function(id, registry_tracker, pool, pool_verify) 
     # When you select a registry
     shiny::observeEvent(input$selected_registry, {
       rv_return$registry_id <- input$selected_registry
+      registry_indicators <- get_registry_indicators(pool_verify, input$selected_registry)
+
+      rv$registry_indicators <- as.list(registry_indicators$id)
+      names(rv$registry_indicators) <- registry_indicators$title
     })
 
     # Select indicator drop down menu
@@ -68,7 +72,7 @@ selected_indicators_server <- function(id, registry_tracker, pool, pool_verify) 
       shiny::req(input$selected_registry)
       shiny::selectInput(
         ns("selected_indicator"), "Velg indikator:",
-        choices = get_registry_indicators(pool_verify, input$selected_registry)$id
+        choices = rv$registry_indicators
       )
     })
 


### PR DESCRIPTION
Foreslår at vi beholder indikator-id i indikatorfanen siden de bruker denne når de laster opp data. 

Fanene for kvalitetsforbedring og utvalgte indikatorer blir slik: 
![image](https://github.com/user-attachments/assets/1396e069-bc5d-4f68-aa7d-bfbdeeb901cd)

### Bonus i opplastingsfanen: 
![image](https://github.com/user-attachments/assets/24abb2e9-1041-4f22-92cd-f7012622ff29)
