### PR TITLE
Fiks aggregering i verify

### DIFF
--- a/R/mod_upload.R
+++ b/R/mod_upload.R
@@ -124,7 +124,7 @@ upload_server <- function(id, registry_tracker, pool_verify) {
         update = input$latest_update,
         affirm = input$latest_affirm
       )
-      insert_agg_data(pool_verify, get_registry_data(pool_verify, input$publish_registry))
+      insert_agg_data(pool_verify, get_registry_data(pool_verify, input$registry))
       rv$inv_data <- rv$inv_data + 1
       shinyalert::shinyalert(conf$upload$reciept$title,
         conf$upload$reciept$body,

--- a/R/mod_upload.R
+++ b/R/mod_upload.R
@@ -124,7 +124,7 @@ upload_server <- function(id, registry_tracker, pool_verify) {
         update = input$latest_update,
         affirm = input$latest_affirm
       )
-      insert_agg_data(pool_verify, input_data())
+      insert_agg_data(pool_verify, get_registry_data(pool_verify, input$publish_registry))
       rv$inv_data <- rv$inv_data + 1
       shinyalert::shinyalert(conf$upload$reciept$title,
         conf$upload$reciept$body,


### PR DESCRIPTION
Har endret opplastingen tilat alle data i verify aggregeres når man laster opp en datafil. 

I `insert_agg_data`-funksjonen i `ops.R` testes det om man laster opp et fullstendig sett av indikatorer. Hvis ikke hentes alle registerets data fra verify for å aggregeres opp på nytt. Denne er nå fjernet slik at man må gi funksjonen de dataene som man ønsker å aggregere. 