### PR TITLE
fix: sorter eksplisitt på år før dekningsgrad legges på agg-data

### DIFF
--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -158,7 +158,7 @@ agg_dg <- function(aggs, ind) {
   # unique years represented by dgs in data, ascending order
   years <- dplyr::select(dg_data, "year") |>
     dplyr::distinct() |>
-    dplyr::arrange(year) |>
+    dplyr::arrange(.data$year) |>
     dplyr::pull()
 
   # dg might not be present for every year, hence start filling in oldest

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -158,7 +158,7 @@ agg_dg <- function(aggs, ind) {
   # unique years represented by dgs in data, ascending order
   years <- dplyr::select(dg_data, "year") |>
     dplyr::distinct() |>
-    dplyr::arrange() |>
+    dplyr::arrange(year) |>
     dplyr::pull()
 
   # dg might not be present for every year, hence start filling in oldest


### PR DESCRIPTION
`dplyr::arrange()` sorterer ikke årstallene riktig. 2025 kommer først, så dekningsgradene for 2025 overskrives. 